### PR TITLE
Remove now flag from systemctl enable calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ WantedBy=timers.target
 
 Enable the timer:
 ```sh
-systemctl enable --now restic-backup.timer
+systemctl enable restic-backup.timer
 ```
 
 ## Create a prune service
@@ -122,5 +122,5 @@ WantedBy=timers.target
 
 Enable the timer:
 ```sh
-systemctl enable --now restic-prune.timer
+systemctl enable restic-prune.timer
 ```


### PR DESCRIPTION
Not even too sure what the `--now` flag does on timers. I assume it starts the service just as when applied to the `.service` 
 unit file itself. In this context the `--now` flag should not be relevant.