### PR TITLE
Prevent idle, sleep and shutdown while executing restic

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ do
     sleep 1
 done
 
-exec restic "$@"
+exec systemd-inhibit restic "$@"
 ```
 Change `<repository>` and `<password>` accordingly.
 If your offsite backup depends on a specific host

--- a/bin/restic-offsite
+++ b/bin/restic-offsite
@@ -8,4 +8,4 @@ do
     sleep 1
 done
 
-exec restic "$@"
+exec systemd-inhibit restic "$@"


### PR DESCRIPTION
This prevents the user from accidentally suspending their system or shutting it down while performing operations, such as `backup`, `forget` and `prune`, on the backup. There is an open issue on [Superuser](https://superuser.com/questions/1568039/allow-non-privileged-user-to-do-systemd-inhibit) where someone was not able to run `systemd-inhibit` as an unprivileged user but I have not been able to reproduce this issue on Fedora 38.  
My testing was performed in the following manner.
1. Log into the unprivileged user
```sh
sudo -u restic zsh
```
2. Run a command using `systemd-inhibit`
```sh
systemd-inhibit echo "Hello World"
```
3. Log out of the unprivileged user
```sh
exit
```
If the above test works just fine on your system, and it should, then it is highly advised to utilise the functionality of `systemd-inhibit` in order to prevent accidental interruptions to the backup process.