### PR TITLE
Fix systemd-inhibit call

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ do
     sleep 1
 done
 
-exec systemd-inhibit restic "$@"
+exec systemd-inhibit --what=idle restic "$@"
 ```
 Change `<repository>` and `<password>` accordingly.
 If your offsite backup depends on a specific host

--- a/bin/restic-offsite
+++ b/bin/restic-offsite
@@ -8,4 +8,4 @@ do
     sleep 1
 done
 
-exec systemd-inhibit restic "$@"
+exec systemd-inhibit --what=idle restic "$@"


### PR DESCRIPTION
So as it turns out the unit file is not able to run `systemd-inhibit` as it is configured right now. For the time being we can only prevent idling, but that already should be better than no protection at all.