### PR TITLE
Check if host is available using ExecStartPre

### DIFF
--- a/install
+++ b/install
@@ -12,6 +12,7 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+ExecStartPre=/bin/sh -c 'until host google.com; do sleep 1; done'
 ExecStart=restic backup %h \\
     --exclude %h/.*
 ExecStartPost=restic forget \\
@@ -43,6 +44,7 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+ExecStartPre=/bin/sh -c 'until host google.com; do sleep 1; done'
 ExecStart=restic prune
 EOL
 


### PR DESCRIPTION
Not checking for this might lead to the system not being able to make a backup.
Ideally, we would check if a _specific_ host is available. But for now we will see how good this solution works.